### PR TITLE
Fix stale data on books index

### DIFF
--- a/src/app/books/index.tsx
+++ b/src/app/books/index.tsx
@@ -5,7 +5,7 @@ import {
   transformDBBookToBookInfo,
 } from "@/lib/database-queries";
 import { useEffect, useRef } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import type { BookInfo } from "@/src/types/book-types";
 import { fetchGoodreadsShelf } from "@/src/lib/goodreads-api";
@@ -92,7 +92,13 @@ export const Route = createFileRoute("/books/")({
 });
 
 function Books() {
-  const { currentBooks } = Route.useLoaderData();
+  const { currentBooks: loaderCurrentBooks } = Route.useLoaderData();
+
+  const { data: currentBooks = loaderCurrentBooks } = useQuery({
+    queryKey: ["currentBooks"],
+    queryFn: () => getCurrentBooks(),
+    initialData: loaderCurrentBooks,
+  });
 
   const {
     data: recentBooksData,


### PR DESCRIPTION
 by managing currentBooks through React Query

currentBooks was only fetched via the route loader, so client-side navigations served cached loader data that never refetched. Wrapping it in useQuery with the loader result as initialData ensures React Query tracks freshness and triggers background refetches when stale.

https://claude.ai/code/session_01Dt1o52SLZpgqAuRRfGESSj