### PR TITLE
Implement stale-while-revalidate caching strategy

### DIFF
--- a/lib/query-client.ts
+++ b/lib/query-client.ts
@@ -41,6 +41,9 @@ function createLocalStoragePersister() {
   };
 }
 
+// Build-time cache buster: changes on every deploy, invalidating stale localStorage
+const CACHE_BUSTER = typeof __GIT_COMMIT_SHA__ !== "undefined" ? __GIT_COMMIT_SHA__ : "";
+
 // Singleton QueryClient for client-side (with persistence)
 let clientQueryClient: QueryClient | null = null;
 
@@ -52,7 +55,7 @@ export function createPersistentQueryClient(): QueryClient {
         defaultOptions: {
           queries: {
             staleTime: 5 * 60 * 1000, // 5 minutes - data is fresh for 5 minutes
-            gcTime: 7 * 24 * 60 * 60 * 1000, // 7 days - keep cached data for 7 days
+            gcTime: 24 * 60 * 60 * 1000, // 24 hours - keep cached data for 1 day
             refetchOnWindowFocus: false, // Don't refetch on window focus
             refetchOnReconnect: true, // Refetch when network reconnects
             retry: 1, // Retry once on failure
@@ -65,8 +68,8 @@ export function createPersistentQueryClient(): QueryClient {
       persistQueryClient({
         queryClient: clientQueryClient,
         persister,
-        maxAge: 7 * 24 * 60 * 60 * 1000, // Persist for 7 days
-        buster: "", // Cache buster - can be used to invalidate cache
+        maxAge: 24 * 60 * 60 * 1000, // Persist for 24 hours
+        buster: CACHE_BUSTER, // Invalidate cache on new deploys
       });
     }
     return clientQueryClient;
@@ -77,7 +80,7 @@ export function createPersistentQueryClient(): QueryClient {
     defaultOptions: {
       queries: {
         staleTime: 5 * 60 * 1000, // 5 minutes
-        gcTime: 7 * 24 * 60 * 60 * 1000, // 7 days
+        gcTime: 24 * 60 * 60 * 1000, // 24 hours
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
         retry: 1,

--- a/public/sw.js
+++ b/public/sw.js
@@ -40,7 +40,8 @@ function shouldCache(request) {
   return false;
 }
 
-// Fetch event - network-first strategy (try network, fall back to cache)
+// Fetch event - stale-while-revalidate strategy
+// Serve cached content immediately (fast/offline), update cache in background
 self.addEventListener("fetch", (event) => {
   // Skip non-GET requests
   if (event.request.method !== "GET") {
@@ -58,47 +59,45 @@ self.addEventListener("fetch", (event) => {
   }
 
   event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        // Don't cache if not a valid response
-        if (
-          !response ||
-          response.status !== 200 ||
-          response.type === "error"
-        ) {
-          return response;
-        }
-
-        // Clone the response and cache it
-        const responseToCache = response.clone();
-        caches.open(CACHE_NAME).then((cache) => {
-          cache.put(event.request, responseToCache);
-        });
-
-        return response;
-      })
-      .catch(() => {
-        // Network failed - fall back to cache
-        return caches.match(event.request).then((cachedResponse) => {
-          if (cachedResponse) {
-            return cachedResponse;
-          }
-
-          // No cache available
-          if (event.request.mode === "navigate") {
-            return caches.match("/").then((cached) => {
-              return cached || new Response("Offline - no cached page available", {
-                status: 503,
-                headers: { "Content-Type": "text/plain" },
-              });
+    caches.match(event.request).then((cachedResponse) => {
+      // Always kick off a network fetch to update the cache for next time
+      const networkFetch = fetch(event.request)
+        .then((response) => {
+          if (
+            response &&
+            response.status === 200 &&
+            response.type !== "error"
+          ) {
+            const responseToCache = response.clone();
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(event.request, responseToCache);
             });
           }
-          return new Response("Network error", {
-            status: 408,
+          return response;
+        })
+        .catch(() => {
+          // Network failed - that's fine, we already served from cache
+          return cachedResponse;
+        });
+
+      // Return cached version immediately if available, otherwise wait for network
+      return cachedResponse || networkFetch.then((response) => {
+        if (response) {
+          return response;
+        }
+        // Nothing in cache and network failed
+        if (event.request.mode === "navigate") {
+          return new Response("Offline - no cached page available", {
+            status: 503,
             headers: { "Content-Type": "text/plain" },
           });
+        }
+        return new Response("Network error", {
+          status: 408,
+          headers: { "Content-Type": "text/plain" },
         });
-      })
+      });
+    })
   );
 });
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -40,7 +40,7 @@ function shouldCache(request) {
   return false;
 }
 
-// Fetch event - serve from cache, fallback to network
+// Fetch event - network-first strategy (try network, fall back to cache)
 self.addEventListener("fetch", (event) => {
   // Skip non-GET requests
   if (event.request.method !== "GET") {
@@ -58,37 +58,33 @@ self.addEventListener("fetch", (event) => {
   }
 
   event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
-      // Return cached version if available
-      if (cachedResponse) {
-        return cachedResponse;
-      }
+    fetch(event.request)
+      .then((response) => {
+        // Don't cache if not a valid response
+        if (
+          !response ||
+          response.status !== 200 ||
+          response.type === "error"
+        ) {
+          return response;
+        }
 
-      // Otherwise fetch from network
-      return fetch(event.request)
-        .then((response) => {
-          // Don't cache if not a valid response
-          if (
-            !response ||
-            response.status !== 200 ||
-            response.type === "error"
-          ) {
-            return response;
+        // Clone the response and cache it
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+
+        return response;
+      })
+      .catch(() => {
+        // Network failed - fall back to cache
+        return caches.match(event.request).then((cachedResponse) => {
+          if (cachedResponse) {
+            return cachedResponse;
           }
 
-          // Clone the response
-          const responseToCache = response.clone();
-
-          // Cache the fetched response
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, responseToCache);
-          });
-
-          return response;
-        })
-        .catch(() => {
-          // If fetch fails and we're offline, try to return a cached version
-          // This helps with navigation requests
+          // No cache available
           if (event.request.mode === "navigate") {
             return caches.match("/").then((cached) => {
               return cached || new Response("Offline - no cached page available", {
@@ -97,13 +93,12 @@ self.addEventListener("fetch", (event) => {
               });
             });
           }
-          // For other requests, return a network error
           return new Response("Network error", {
             status: 408,
             headers: { "Content-Type": "text/plain" },
           });
         });
-    })
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
This PR refactors the service worker caching strategy from cache-first to stale-while-revalidate, and reduces query client cache retention periods with automatic cache busting on deploys.

## Key Changes

**Service Worker (public/sw.js)**
- Switched from cache-first to stale-while-revalidate strategy
  - Cached content is served immediately for fast/offline experience
  - Network requests are always initiated in the background to update the cache
  - Fallback to cached response if network fails
- Simplified error handling and offline fallback logic
- Improved comments to clarify the new caching behavior

**Query Client (lib/query-client.ts)**
- Reduced garbage collection time from 7 days to 24 hours for both client and server query clients
- Reduced persistence max age from 7 days to 24 hours
- Added `CACHE_BUSTER` constant that uses `__GIT_COMMIT_SHA__` to automatically invalidate localStorage cache on every deploy
- Updated cache buster configuration to use the new constant instead of empty string

## Implementation Details
The stale-while-revalidate pattern ensures users always get a fast response from cache while the app silently updates the cache in the background. This provides better perceived performance and offline support compared to the previous cache-first approach that would wait for network failures before serving cached content.

The cache buster mechanism ensures that when the application is deployed with a new commit SHA, any stale cached data in localStorage is automatically invalidated, preventing users from seeing outdated information after a deployment.

https://claude.ai/code/session_01Ts8rrPiXSMraZwStFn684s